### PR TITLE
Add mapdex.json for domain configuration

### DIFF
--- a/domains/mapdex.json
+++ b/domains/mapdex.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "khalisghilmanou96-dev",
+    "email": "khalisghilmanou@gmail.com"
+  },
+  "records": {
+    "CNAME": "khalisghilmanou96-dev.github.io"
+  }
+}


### PR DESCRIPTION
map index

<!--
Fill out this template so your subdomain can be reviewed quickly. PRs that
ignore it may be closed without explanation.
-->

# Requirements
<!-- Change each [ ] to [x] (lowercase, no spaces) to confirm. -->

- [x] I **agree** to the [Terms of Service](../TERMS_OF_SERVICE.md).
- [x] My PR adds or edits a single `domains/<subdomain>.json` following the [structure](../CONTRIBUTING.md).
- [x] `owner.username` matches my GitHub username.
- [x] My subdomain is **not** used for phishing, malware, spam, impersonation, or illegal content.
- [x] I added a link and/or screenshot preview below.

# What is it for?
An interactive map web application hosted on GitHub Pages.
# Subdomain
mapdex.fluxcast.dev
# Preview
https://khalisghilmanou96-dev.github.io/mapdex/